### PR TITLE
Update ESLINT configuration to use new Flat config format

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ export default tseslint.config({
   rules: {
     // other rules...
     // Enable its recommended rules
-    ...react.configs.recommended.rules,
-    ...react.configs['jsx-runtime'].rules,
+    ...react.configs.flat.recommended.rules,
+    ...react.configs.falt['jsx-runtime'].rules,
   },
 })
 ```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,18 +2,25 @@ import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import react from 'eslint-plugin-react';
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
   { ignores: ['dist'] },
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    extends: [js.configs.recommended, ...tseslint.configs.recommendedTypeChecked, ...tseslint.configs.stylisticTypeChecked],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        project: ['./tsconfig.node.json', './tsconfig.app.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
+    settings: { react: { version: '18.3' } },
     plugins: {
+      react,
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
     },
@@ -23,6 +30,8 @@ export default tseslint.config(
         'warn',
         { allowConstantExport: true },
       ],
+      ...react.configs.flat.recommended.rules,
+      ...react.configs.flat['jsx-runtime'].rules,
     },
   },
 )

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
     "eslint": "^9.9.0",
+    "eslint-plugin-react": "^7.37.1",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.9.0",


### PR DESCRIPTION
ESLint introduced a new configuration format called [Flat Config](https://github.com/jsx-eslint/eslint-plugin-react/?tab=readme-ov-file#flat-configs). 

- This page explains how to use flat config files: [ESLint Configuration Files](https://eslint.org/docs/latest/use/configure/configuration-files)